### PR TITLE
MN-9: Added the latest module-react-component version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/uuid": "^9.0.7",
-        "@wert-io/module-react-component": "2.1.3",
+        "@wert-io/module-react-component": "3.0.1",
         "@wert-io/widget-initializer": "6.8.2",
         "@wert-io/widget-sc-signer": "2.0.1",
         "buffer": "^6.0.3",
@@ -3080,12 +3080,12 @@
       }
     },
     "node_modules/@wert-io/module-react-component": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@wert-io/module-react-component/-/module-react-component-2.1.3.tgz",
-      "integrity": "sha512-FNb3Y+X7T1okSBepZ19gz14yJhI3Oi1q7inLuhg3IbW95ApdgITrUaf0Vn3Fc/W2mj5U6QHz+8buTo+E/ePA6Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@wert-io/module-react-component/-/module-react-component-3.0.1.tgz",
+      "integrity": "sha512-mK0EjyeVCpVGLQ4YyFZ+u4tltaSv3CQri1xaGQrOZBR7zG+tvi2TKxAksdXzp2ws1URzFTkwp/geqeFS6HTbkQ==",
+      "license": "ISC",
       "dependencies": {
-        "@wert-io/widget-initializer": "6.3.1",
-        "@wert-io/widget-sc-signer": "2.0.1",
+        "@wert-io/widget-initializer": "6.9.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
       },
@@ -3095,9 +3095,10 @@
       }
     },
     "node_modules/@wert-io/module-react-component/node_modules/@wert-io/widget-initializer": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-6.3.1.tgz",
-      "integrity": "sha512-7iGs+QE58d6XOCBQhJf7tCmoOBmKq8Daw4LR/EJHjZoD9XIhb4RpSNPnFzFzmpmtqPCnffi1ul2ruhvMPnp6SA=="
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-6.9.0.tgz",
+      "integrity": "sha512-XSNAuyiD2rX+Iez32XSGPuKPwC0f0YAEQi0RSn6yTc9hTz97GzcIAxpRCPFDAjSMGJtJCkp+YV//QCdm/Ecbng==",
+      "license": "ISC"
     },
     "node_modules/@wert-io/widget-initializer": {
       "version": "6.8.2",
@@ -10337,20 +10338,19 @@
       "requires": {}
     },
     "@wert-io/module-react-component": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@wert-io/module-react-component/-/module-react-component-2.1.3.tgz",
-      "integrity": "sha512-FNb3Y+X7T1okSBepZ19gz14yJhI3Oi1q7inLuhg3IbW95ApdgITrUaf0Vn3Fc/W2mj5U6QHz+8buTo+E/ePA6Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@wert-io/module-react-component/-/module-react-component-3.0.1.tgz",
+      "integrity": "sha512-mK0EjyeVCpVGLQ4YyFZ+u4tltaSv3CQri1xaGQrOZBR7zG+tvi2TKxAksdXzp2ws1URzFTkwp/geqeFS6HTbkQ==",
       "requires": {
-        "@wert-io/widget-initializer": "6.3.1",
-        "@wert-io/widget-sc-signer": "2.0.1",
+        "@wert-io/widget-initializer": "6.9.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
       },
       "dependencies": {
         "@wert-io/widget-initializer": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-6.3.1.tgz",
-          "integrity": "sha512-7iGs+QE58d6XOCBQhJf7tCmoOBmKq8Daw4LR/EJHjZoD9XIhb4RpSNPnFzFzmpmtqPCnffi1ul2ruhvMPnp6SA=="
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-6.9.0.tgz",
+          "integrity": "sha512-XSNAuyiD2rX+Iez32XSGPuKPwC0f0YAEQi0RSn6yTc9hTz97GzcIAxpRCPFDAjSMGJtJCkp+YV//QCdm/Ecbng=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/uuid": "^9.0.7",
         "@wert-io/module-react-component": "3.0.1",
-        "@wert-io/widget-initializer": "6.8.2",
+        "@wert-io/widget-initializer": "6.9.0",
         "@wert-io/widget-sc-signer": "2.0.1",
         "buffer": "^6.0.3",
         "react": "^18.3.1",
@@ -3094,16 +3094,10 @@
         "react-dom": "^18.1.0"
       }
     },
-    "node_modules/@wert-io/module-react-component/node_modules/@wert-io/widget-initializer": {
+    "node_modules/@wert-io/widget-initializer": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-6.9.0.tgz",
       "integrity": "sha512-XSNAuyiD2rX+Iez32XSGPuKPwC0f0YAEQi0RSn6yTc9hTz97GzcIAxpRCPFDAjSMGJtJCkp+YV//QCdm/Ecbng==",
-      "license": "ISC"
-    },
-    "node_modules/@wert-io/widget-initializer": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-6.8.2.tgz",
-      "integrity": "sha512-StqCWWrr6kU988qlJYKvSPvPQwl9dwA7YNhUZmxtCbw+aHIqCudHU6z5xUdlmRisS99smEEkeE1da9P4LbyriA==",
       "license": "ISC"
     },
     "node_modules/@wert-io/widget-sc-signer": {
@@ -10345,19 +10339,12 @@
         "@wert-io/widget-initializer": "6.9.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
-      },
-      "dependencies": {
-        "@wert-io/widget-initializer": {
-          "version": "6.9.0",
-          "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-6.9.0.tgz",
-          "integrity": "sha512-XSNAuyiD2rX+Iez32XSGPuKPwC0f0YAEQi0RSn6yTc9hTz97GzcIAxpRCPFDAjSMGJtJCkp+YV//QCdm/Ecbng=="
-        }
       }
     },
     "@wert-io/widget-initializer": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-6.8.2.tgz",
-      "integrity": "sha512-StqCWWrr6kU988qlJYKvSPvPQwl9dwA7YNhUZmxtCbw+aHIqCudHU6z5xUdlmRisS99smEEkeE1da9P4LbyriA=="
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-6.9.0.tgz",
+      "integrity": "sha512-XSNAuyiD2rX+Iez32XSGPuKPwC0f0YAEQi0RSn6yTc9hTz97GzcIAxpRCPFDAjSMGJtJCkp+YV//QCdm/Ecbng=="
     },
     "@wert-io/widget-sc-signer": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@types/uuid": "^9.0.7",
     "@wert-io/module-react-component": "3.0.1",
-    "@wert-io/widget-initializer": "6.8.2",
+    "@wert-io/widget-initializer": "6.9.0",
     "@wert-io/widget-sc-signer": "2.0.1",
     "buffer": "^6.0.3",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wert-io/widget-integration-example#readme",
   "dependencies": {
     "@types/uuid": "^9.0.7",
-    "@wert-io/module-react-component": "2.1.3",
+    "@wert-io/module-react-component": "3.0.1",
     "@wert-io/widget-initializer": "6.8.2",
     "@wert-io/widget-sc-signer": "2.0.1",
     "buffer": "^6.0.3",

--- a/src/react-module.tsx
+++ b/src/react-module.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 
 import { useWertWidget } from '@wert-io/module-react-component';
 import type {
-  GeneralOptions,
+  StaticOptions,
   ReactiveOptions,
 } from '@wert-io/module-react-component';
 
@@ -15,7 +15,7 @@ import type {
 
 const WertButton: React.FC = () => {
   // Here goes the list of all static options. This object is then passed to the open() method
-  const options: GeneralOptions = {
+  const options: StaticOptions = {
     partner_id: 'default',
     origin: 'https://sandbox.wert.io', // this option needed only in sandbox
     commodity: 'ETH',
@@ -33,7 +33,7 @@ const WertButton: React.FC = () => {
   return (
     <button
       onClick={() => {
-        open({ options });
+        open(options);
       }}
     >
       Open Wert widget


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade Wert packages and adjust the React example to use StaticOptions and the updated open(options) API.
> 
> - **Dependencies**:
>   - Upgrade `@wert-io/module-react-component` from `2.1.3` to `3.0.1`.
>   - Upgrade `@wert-io/widget-initializer` from `6.8.2` to `6.9.0`.
> - **React example update (`src/react-module.tsx`)**:
>   - Switch `GeneralOptions` to `StaticOptions`.
>   - Update API usage to call `open(options)` instead of `open({ options })`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d60c55bcb663af24bf965cbd3cc86943a164ad0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->