### PR TITLE
MN-333: upgraded widget-initializer to 7.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@wert-io/module-react-component": "3.0.1",
-        "@wert-io/widget-initializer": "7.0.1",
+        "@wert-io/widget-initializer": "7.0.2",
         "@wert-io/widget-sc-signer": "2.0.1",
         "buffer": "6.0.3",
         "react": "18.3.1",
@@ -3102,9 +3102,10 @@
       "license": "ISC"
     },
     "node_modules/@wert-io/widget-initializer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.1.tgz",
-      "integrity": "sha512-/0IYjYFo2iVXGNC47HGQ7uGMJ4pxpue7Zr8obJnSHc3CfqlmMPXMAcZBg+0b6SM3qT3sShOIIqmn/GgCeIcrbg=="
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.2.tgz",
+      "integrity": "sha512-L7PyITRV3x/hF8nuKA3LmVkKAuW5C30ZW4VvOUCVKWc1evEkY/cgtGqDG64ogTk6qED433tWOqaLIFFfvUlZ3Q==",
+      "license": "ISC"
     },
     "node_modules/@wert-io/widget-sc-signer": {
       "version": "2.0.1",
@@ -10356,9 +10357,9 @@
       }
     },
     "@wert-io/widget-initializer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.1.tgz",
-      "integrity": "sha512-/0IYjYFo2iVXGNC47HGQ7uGMJ4pxpue7Zr8obJnSHc3CfqlmMPXMAcZBg+0b6SM3qT3sShOIIqmn/GgCeIcrbg=="
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.2.tgz",
+      "integrity": "sha512-L7PyITRV3x/hF8nuKA3LmVkKAuW5C30ZW4VvOUCVKWc1evEkY/cgtGqDG64ogTk6qED433tWOqaLIFFfvUlZ3Q=="
     },
     "@wert-io/widget-sc-signer": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wert-io/widget-integration-example#readme",
   "dependencies": {
     "@wert-io/module-react-component": "3.0.1",
-    "@wert-io/widget-initializer": "7.0.1",
+    "@wert-io/widget-initializer": "7.0.2",
     "@wert-io/widget-sc-signer": "2.0.1",
     "buffer": "6.0.3",
     "react": "18.3.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single patch-level dependency upgrade with no application code changes; risk is limited to any behavior changes inside the updated package.
> 
> **Overview**
> Updates `@wert-io/widget-initializer` from `7.0.1` to `7.0.2` in `package.json` and syncs `package-lock.json` to the new resolved tarball/integrity metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 127209db02a3a35a38742b847cb62d31790191cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->