### PR TITLE
MN-370 Upgrade widget-initializer to 7.0.3 in corresponding projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@wert-io/module-react-component": "3.0.1",
-        "@wert-io/widget-initializer": "7.0.2",
+        "@wert-io/widget-initializer": "7.0.3",
         "@wert-io/widget-sc-signer": "2.0.1",
         "buffer": "6.0.3",
         "react": "18.3.1",
@@ -3102,9 +3102,9 @@
       "license": "ISC"
     },
     "node_modules/@wert-io/widget-initializer": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.2.tgz",
-      "integrity": "sha512-L7PyITRV3x/hF8nuKA3LmVkKAuW5C30ZW4VvOUCVKWc1evEkY/cgtGqDG64ogTk6qED433tWOqaLIFFfvUlZ3Q==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.3.tgz",
+      "integrity": "sha512-ww0o0sQxvuslSLyA4OA42fwmlShF3PI5HxjwP10N2NO17PzQHp0qRhkCiT7zpje1bgHTs7Z9pDG+U2Hot/S0Xg==",
       "license": "ISC"
     },
     "node_modules/@wert-io/widget-sc-signer": {
@@ -10357,9 +10357,9 @@
       }
     },
     "@wert-io/widget-initializer": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.2.tgz",
-      "integrity": "sha512-L7PyITRV3x/hF8nuKA3LmVkKAuW5C30ZW4VvOUCVKWc1evEkY/cgtGqDG64ogTk6qED433tWOqaLIFFfvUlZ3Q=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.3.tgz",
+      "integrity": "sha512-ww0o0sQxvuslSLyA4OA42fwmlShF3PI5HxjwP10N2NO17PzQHp0qRhkCiT7zpje1bgHTs7Z9pDG+U2Hot/S0Xg=="
     },
     "@wert-io/widget-sc-signer": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wert-io/widget-integration-example#readme",
   "dependencies": {
     "@wert-io/module-react-component": "3.0.1",
-    "@wert-io/widget-initializer": "7.0.2",
+    "@wert-io/widget-initializer": "7.0.3",
     "@wert-io/widget-sc-signer": "2.0.1",
     "buffer": "6.0.3",
     "react": "18.3.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level dependency bump with no repo code changes; risk depends on upstream 7.0.3 widget behavior, not local edits.
> 
> **Overview**
> Bumps the direct **`@wert-io/widget-initializer`** dependency from **7.0.2** to **7.0.3** in `package.json`, with matching lockfile updates for the resolved tarball and integrity hash.
> 
> No application or example source files are changed—only the dependency version for this Wert widget integration example repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e4c894003e0f813e04ada00ce835a2ce555c8e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->