### PR TITLE
DEVS-10057 Upgrade widget-initializer to 7.0.5 in corresponding projects 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@wert-io/module-react-component": "3.0.1",
-        "@wert-io/widget-initializer": "7.0.3",
+        "@wert-io/widget-initializer": "7.0.5",
         "@wert-io/widget-sc-signer": "2.0.1",
         "buffer": "6.0.3",
         "react": "18.3.1",
@@ -3102,9 +3102,9 @@
       "license": "ISC"
     },
     "node_modules/@wert-io/widget-initializer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.3.tgz",
-      "integrity": "sha512-ww0o0sQxvuslSLyA4OA42fwmlShF3PI5HxjwP10N2NO17PzQHp0qRhkCiT7zpje1bgHTs7Z9pDG+U2Hot/S0Xg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.5.tgz",
+      "integrity": "sha512-Gaed1AmHScYMfZ7T+bAkywueVnOdGkdefFJF+0Zpw2aleFPjJCRXCHUfPDBiOz/9OKGaorHpIETKSirJOOUisw==",
       "license": "ISC"
     },
     "node_modules/@wert-io/widget-sc-signer": {
@@ -10357,9 +10357,9 @@
       }
     },
     "@wert-io/widget-initializer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.3.tgz",
-      "integrity": "sha512-ww0o0sQxvuslSLyA4OA42fwmlShF3PI5HxjwP10N2NO17PzQHp0qRhkCiT7zpje1bgHTs7Z9pDG+U2Hot/S0Xg=="
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.5.tgz",
+      "integrity": "sha512-Gaed1AmHScYMfZ7T+bAkywueVnOdGkdefFJF+0Zpw2aleFPjJCRXCHUfPDBiOz/9OKGaorHpIETKSirJOOUisw=="
     },
     "@wert-io/widget-sc-signer": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wert-io/widget-integration-example#readme",
   "dependencies": {
     "@wert-io/module-react-component": "3.0.1",
-    "@wert-io/widget-initializer": "7.0.3",
+    "@wert-io/widget-initializer": "7.0.5",
     "@wert-io/widget-sc-signer": "2.0.1",
     "buffer": "6.0.3",
     "react": "18.3.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only patch bump with no repo code changes; risk is limited to behavior changes inside the external widget package.
> 
> **Overview**
> Bumps the direct **`@wert-io/widget-initializer`** dependency from **7.0.3** to **7.0.5** in `package.json`, with the matching lockfile resolution and integrity hash updates in `package-lock.json`.
> 
> No application source changes; this is a patch-level widget SDK upgrade for the integration example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be105749443437152f0d90d6152e1d83bd53f434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->