### PR TITLE
MN-408: upgrade @wert-io/widget-initializer to version 7.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@wert-io/module-react-component": "3.0.1",
-        "@wert-io/widget-initializer": "7.0.5",
+        "@wert-io/widget-initializer": "7.0.6",
         "@wert-io/widget-sc-signer": "2.0.1",
         "buffer": "6.0.3",
         "react": "18.3.1",
@@ -3102,9 +3102,9 @@
       "license": "ISC"
     },
     "node_modules/@wert-io/widget-initializer": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.5.tgz",
-      "integrity": "sha512-Gaed1AmHScYMfZ7T+bAkywueVnOdGkdefFJF+0Zpw2aleFPjJCRXCHUfPDBiOz/9OKGaorHpIETKSirJOOUisw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.6.tgz",
+      "integrity": "sha512-ui9k/O4x0cxtwkNBK6IW8fdyGDgT7HkFf+RjPLjPDHTPPe12kNwJcS7kBtsiILowbS7fUEidi9dxI1/Oq8KPLA==",
       "license": "ISC"
     },
     "node_modules/@wert-io/widget-sc-signer": {
@@ -10357,9 +10357,9 @@
       }
     },
     "@wert-io/widget-initializer": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.5.tgz",
-      "integrity": "sha512-Gaed1AmHScYMfZ7T+bAkywueVnOdGkdefFJF+0Zpw2aleFPjJCRXCHUfPDBiOz/9OKGaorHpIETKSirJOOUisw=="
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.6.tgz",
+      "integrity": "sha512-ui9k/O4x0cxtwkNBK6IW8fdyGDgT7HkFf+RjPLjPDHTPPe12kNwJcS7kBtsiILowbS7fUEidi9dxI1/Oq8KPLA=="
     },
     "@wert-io/widget-sc-signer": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wert-io/widget-integration-example#readme",
   "dependencies": {
     "@wert-io/module-react-component": "3.0.1",
-    "@wert-io/widget-initializer": "7.0.5",
+    "@wert-io/widget-initializer": "7.0.6",
     "@wert-io/widget-sc-signer": "2.0.1",
     "buffer": "6.0.3",
     "react": "18.3.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level dependency bump with no local code changes; risk depends on upstream widget behavior in 7.0.6, which should be validated via smoke tests of the integration example.
> 
> **Overview**
> Bumps the direct dependency **`@wert-io/widget-initializer`** from **7.0.5** to **7.0.6** in `package.json`, with matching updates in `package-lock.json` (resolved tarball and integrity hash). No application source changes are included in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656dbf7e30c870ae35c1410e31caa7e34f67b525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->